### PR TITLE
Testing

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -15,6 +15,7 @@ function submitForm() {
     $.post("/submit_text", { textfield: text }, function (data) {
         alert(data);
         $("#popup-form").hide();
+        location.reload();
     });
 
     $("#textfield").val('');
@@ -110,14 +111,12 @@ document.addEventListener('keydown', function(event) {
 
         ) {
         showPopup();
-        event.preventDefault();
     }
     else if(
         event.key==='c' && 
         $("#popup-form").is(":hidden") && $("#popup-form-delete-child").is(":hidden") && $("#popup-form-delete-parent").is(":hidden")
         ) {
         showPopupAddChild();
-        event.preventDefault();
     }
     else if (
         event.key === 'A' && 
@@ -125,7 +124,6 @@ document.addEventListener('keydown', function(event) {
         $("#popup-form").is(":hidden") && $("#popup-form-add-child").is(":hidden") && $("#popup-form-delete-child").is(":hidden")
         ) {
         showPopupDeleteParent();
-        event.preventDefault();
     }
     else if(
         event.key === 'C' && 
@@ -133,7 +131,6 @@ document.addEventListener('keydown', function(event) {
         $("#popup-form").is(":hidden") && $("#popup-form-add-child").is(":hidden") && $("#popup-form-delete-parent").is(":hidden")
         ) {
         showPopupDeleteChild();
-        event.preventDefault();
     }
 });
 


### PR DESCRIPTION
Add auto page reload upon parent addition

Fix issue where keybind used to open parent/child add/delete can't be used in input box.
- This introduces new issue where upon pressing keybind to open a submission menu, it types it into the input box immediately (so you have to manually remove it, then type the name for the parent/child)